### PR TITLE
Include regression tests in PyPI tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ recursive-include src *.cpp
 recursive-include src *.cxx
 recursive-include src *.h
 recursive-include src *.inc
+recursive-include tests


### PR DESCRIPTION
In OpenBSD, we like to have the regression tests available in the tarball so we can easily do regression tests when updating ports.