### PR TITLE
fix type conversion error on 64-bit system

### DIFF
--- a/src/Texture2DDecoder/crunch/crn_decomp.h
+++ b/src/Texture2DDecoder/crunch/crn_decomp.h
@@ -29,6 +29,7 @@
 
 //memcpy fix
 #include <cstring>
+#include <stdint.h>
 using namespace std; 
 
 // malloc_useable_size fix
@@ -2550,7 +2551,7 @@ namespace crnd
          return NULL;
       }
 
-      CRND_ASSERT(((uint32)p_new & (CRND_MIN_ALLOC_ALIGNMENT - 1)) == 0);
+      CRND_ASSERT(((uintptr_t)p_new & (CRND_MIN_ALLOC_ALIGNMENT - 1)) == 0);
 
       return p_new;
    }
@@ -2575,7 +2576,7 @@ namespace crnd
       if (pActual_size)
          *pActual_size = actual_size;
 
-      CRND_ASSERT(((uint32)p_new & (CRND_MIN_ALLOC_ALIGNMENT - 1)) == 0);
+      CRND_ASSERT(((uintptr_t)p_new & (CRND_MIN_ALLOC_ALIGNMENT - 1)) == 0);
 
       return p_new;
    }


### PR DESCRIPTION
## Issue Description
The compilation fails on 64-bit systems due to precision loss when casting pointers to `uint32`. The error occurs in `src/Texture2DDecoder/crunch/crn_decomp.h` where pointer values are being cast to 32-bit integers:

```cpp
CRND_ASSERT(((uint32)p_new & (CRND_MIN_ALLOC_ALIGNMENT - 1)) == 0);
```

This causes the following error:

`error: cast from 'crnd::uint8' {aka 'unsigned char'} to 'crnd::uint32' {aka 'unsigned int'} loses precision [-fpermissive]`


## Root Cause
On 64-bit systems, pointers are 64 bits wide, while `uint32` is only 32 bits. Casting a pointer to `uint32` results in potential data loss as the upper 32 bits are truncated.

## Solution
Replace `uint32` with `uintptr_t` for pointer-to-integer conversions:


```cpp
#include <stdint.h>
// Modified assertions
CRND_ASSERT(((uintptr_t)p_new & (CRND_MIN_ALLOC_ALIGNMENT - 1)) == 0);
```

## Benefits
1. Portable across different architectures (32-bit and 64-bit systems)
2. No precision loss when converting between pointers and integers
3. Follows C/C++ best practices for pointer arithmetic
4. Eliminates compiler warnings and errors related to pointer-to-integer conversions